### PR TITLE
Discord RPC Locations & Inventory Sounds Adds

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ A Quality of Life mod designed to enhance your StarNet experience. With features
 
 ## 📝 Features
 1. **Discord Integration:** Share your in-game activities with friends! Whether you’re fishing, farming, or exploring, let them know exactly what you're up to.
-2. **Customizable Hotkeys:** Access everything you need with a keypress! From opening your storage pouch to teleporting to your island, there’s a hotkey for every action.
+2. **Customizable Hotkeys:** Access everything you need with a keypress! From opening the social pad to teleporting to your island, there’s a hotkey for every action.
 3. **Cosmetic Enhancements:** Easily adjust or disable cosmetics to suit your style, or fix their positioning for a cleaner look.

--- a/src/main/java/com/playstarnet/essentials/StarNetEssentials.java
+++ b/src/main/java/com/playstarnet/essentials/StarNetEssentials.java
@@ -7,6 +7,7 @@ import com.playstarnet.essentials.feat.keyboard.HPKeybinds;
 import com.playstarnet.essentials.feat.lifecycle.Lifecycle;
 import com.playstarnet.essentials.feat.lifecycle.Task;
 import com.playstarnet.essentials.feat.location.Location;
+import com.playstarnet.essentials.feat.sound.SoundManager;
 import com.playstarnet.essentials.util.Constants;
 import io.netty.buffer.Unpooled;
 import net.fabricmc.api.ClientModInitializer;
@@ -31,13 +32,13 @@ public class StarNetEssentials implements ClientModInitializer {
     private static Location LOCATION = Location.UNKNOWN;
     private static Lifecycle LIFECYCLE;
     private static final HPKeybinds KEYBINDS = new HPKeybinds();
+    public static final String MOD_ID = "starnet_essentials";
 
     @Override
     public void onInitializeClient() {
         Constants.MOD_MENU_PRESENT = FabricLoader.getInstance().isModLoaded("modmenu");
 
         LIFECYCLE = new Lifecycle();
-
         try {
             if (GeneralConfigModel.DISCORD_RPC.value) DISCORD_MANAGER.start();
         } catch (Error err) {
@@ -47,6 +48,7 @@ public class StarNetEssentials implements ClientModInitializer {
 
         lifecycle()
                 .add(Task.of(Location::check, 40))
+                .add(Task.of(SoundManager::initialize, 0))
                 .add(Task.of(() -> {
                     try {
                         if (DiscordManager.active) DISCORD_MANAGER.updateDiscordPresence();

--- a/src/main/java/com/playstarnet/essentials/feat/keyboard/HPKeybinds.java
+++ b/src/main/java/com/playstarnet/essentials/feat/keyboard/HPKeybinds.java
@@ -24,10 +24,10 @@ public class HPKeybinds {
     public void tick() {
         Minecraft client = StarNetEssentials.client();
 
-        while (KeybindModel.POUCH.keyMapping.consumeClick()) {
+        while (KeybindModel.SOCIALPAD.keyMapping.consumeClick()) {
             if (client.player != null) {
                 // Access the item in the 8th hotbar slot (index 7, zero-based)
-                interactWithSlot(client, 7);
+                interactWithSlot(client, 8);
             }
         }
 

--- a/src/main/java/com/playstarnet/essentials/feat/keyboard/model/KeybindModel.java
+++ b/src/main/java/com/playstarnet/essentials/feat/keyboard/model/KeybindModel.java
@@ -6,8 +6,8 @@ import net.minecraft.client.KeyMapping;
 import org.lwjgl.glfw.GLFW;
 
 public enum KeybindModel {
-    POUCH(
-            "key.se.pouch",
+    SOCIALPAD(
+            "key.se.socalpad",
             InputConstants.Type.KEYSYM,
             GLFW.GLFW_KEY_G,
             KeybindCategoryModel.STARNET_ESSENTIALS.translationString

--- a/src/main/java/com/playstarnet/essentials/feat/location/Location.java
+++ b/src/main/java/com/playstarnet/essentials/feat/location/Location.java
@@ -152,7 +152,7 @@ public enum Location {
 		if (checkLocation(playerLocation, new Vec3(262, 5, 199), "MAZIES_FARM", 20)) return;
 		if (checkLocation(playerLocation, new Vec3(218, -27, 153), "FURNITURE_CRAFTER", 10)) return;
 		if (checkLocation(playerLocation, new Vec3(-4245, 83, -1257), "SKULL_CAVES", 70)) return;
-		if (checkLocation(playerLocation, new Vec3(241, 8, 213), "LUMBERJACK", 15)) return;
+		if (checkLocation(playerLocation, new Vec3(245, -8, 215), "LUMBERJACK", 15)) return;
 
 		// Check for island name in the boss bar only if in the world "genworld"
 		if (client.level != null && "genworld".equals(client.level.dimension().location().getPath())) {

--- a/src/main/java/com/playstarnet/essentials/feat/location/Location.java
+++ b/src/main/java/com/playstarnet/essentials/feat/location/Location.java
@@ -71,9 +71,27 @@ public enum Location {
 	),
 
 	// Minigames
-	TRICK_OR_TREAT(
-			"Trick or Treat",
-			"Look at that view! 🏝️",
+	BEACH_FIGHT(
+			"Beach FIGHT!!",
+			"Splashing Around",
+			PresenceImage.Large.STAR,
+			PresenceImage.Small.ROUNDEL
+	),
+	AIR_TACKLE(
+			"Playing Air Tackle",
+			"Trying not to fall off.",
+			PresenceImage.Large.STAR,
+			PresenceImage.Small.ROUNDEL
+	),
+	PIZZA_PARTY(
+			"Playing Pizza Party",
+			"Too many orders!!!",
+			PresenceImage.Large.STAR,
+			PresenceImage.Small.ROUNDEL
+	),
+	PARKOUR(
+			"Playing Parkour Race",
+			"",
 			PresenceImage.Large.STAR,
 			PresenceImage.Small.ROUNDEL
 	),
@@ -130,10 +148,10 @@ public enum Location {
 
 		// Sequential location-based checks with early return on match
 		if (checkLocation(playerLocation, new Vec3(87, -30, 43), "FISHING_HOUSE", 25)) return;
-		if (checkLocation(playerLocation, new Vec3(197, -28, 147), "DAZZLES_COSMETICS", 5)) return;
+		if (checkLocation(playerLocation, new Vec3(185, -23, 218), "DAZZLES_COSMETICS", 5)) return;
 		if (checkLocation(playerLocation, new Vec3(262, 5, 199), "MAZIES_FARM", 20)) return;
 		if (checkLocation(playerLocation, new Vec3(218, -27, 153), "FURNITURE_CRAFTER", 10)) return;
-		if (checkLocation(playerLocation, new Vec3(-4247, 71, -1390), "SKULL_CAVES", 60)) return;
+		if (checkLocation(playerLocation, new Vec3(-4245, 83, -1257), "SKULL_CAVES", 70)) return;
 		if (checkLocation(playerLocation, new Vec3(241, 8, 213), "LUMBERJACK", 15)) return;
 
 		// Check for island name in the boss bar only if in the world "genworld"

--- a/src/main/java/com/playstarnet/essentials/feat/sound/SoundManager.java
+++ b/src/main/java/com/playstarnet/essentials/feat/sound/SoundManager.java
@@ -1,0 +1,35 @@
+package com.playstarnet.essentials.feat.sound;
+
+import com.playstarnet.essentials.StarNetEssentials;
+import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.inventory.InventoryScreen;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.resources.ResourceLocation;
+
+public class SoundManager {
+
+	private static final ResourceLocation INTERFACE_CLICK_ID = ResourceLocation.parse("minecraft:interface_click");
+	public static SoundEvent INTERFACE_CLICK_EVENT = SoundEvent.createVariableRangeEvent(INTERFACE_CLICK_ID);
+
+	private static final Minecraft client = Minecraft.getInstance();
+
+	public static void initialize() {
+		ScreenEvents.AFTER_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
+			// Only play sound if the screen is InventoryScreen and connected to the correct server
+			if (screen instanceof InventoryScreen && StarNetEssentials.connected()) {
+				playInventoryOpenSound();
+			}
+		});
+	}
+
+	private static void playInventoryOpenSound() {
+		if (client.player != null) {
+			if (client.getSoundManager().getSoundEvent(INTERFACE_CLICK_ID) != null) {
+				client.player.playSound(INTERFACE_CLICK_EVENT, 0.7F, 1.0F); // Volume 1.0F, Pitch 1.0F
+			} else {
+
+			}
+		}
+	}
+}

--- a/src/main/resources/assets/starnet_essentials/lang/en_us.json
+++ b/src/main/resources/assets/starnet_essentials/lang/en_us.json
@@ -2,7 +2,7 @@
     "categories.se": "StarNet Essentials",
 
     "key.se.menu": "Open StarNet Essentials Menu",
-    "key.se.pouch": "Open Storage Pouch",
+    "key.se.socalpad": "Open Social Pad",
     "key.se.profile": "Open Profile",
     "key.se.mail": "Open Mail",
     "key.se.map": "Open Map",


### PR DESCRIPTION
- Changed Skull Cave Location for RPC
- Changed Dazzles Cosmetic Location for RPC
- Added sound for opening Inventory as suggested by DB20
- Changed Open Pouch keybind to open Social Pad instead
- Added some the start of discord RPC for mini games
